### PR TITLE
フィルターをかけるリンク名を取得する処理を変更しました。

### DIFF
--- a/config/robot_self_filter.yaml
+++ b/config/robot_self_filter.yaml
@@ -1,15 +1,9 @@
 min_sensor_dist: .2
 self_see_default_padding: .1
 self_see_default_scale: 1.0
-self_see_links:
-  - name: J1
-  - name: J2
-  - name: J3
-  - name: J4
-  - name: J5
-  - name: J6
-  - name: hand_link
-  - name: mhand_body_link
-  - name: mhand_finger_A
-  - name: mhand_finger_B
-  - name: mhand_finger_C
+keep_organized: true
+subsample_value: 0.0
+use_rgb: false
+# see_link_names: 
+ignore_link_names:
+   - name: world

--- a/launch/robot_self_filter.launch
+++ b/launch/robot_self_filter.launch
@@ -1,22 +1,10 @@
 <launch>
-  <arg name="robot_filter_pc_src" default="/photoneo_center/pointcloud" />
-  <arg name="robot_filter_pc_dst" default="/robot_filtered_cloud" />
-  <arg name="robot_filter_min_sensor_dist" default="0.2" />
-  <arg name="robot_filter_self_see_default_padding" default="0.1" />
-  <arg name="robot_filter_self_see_default_scale" default="1.0" />
-  <arg name="robot_filter_keep_organized" default="true" />
-  <arg name="robot_filter_subsample_value" default="0.0" />
-  <arg name="use_rgb" default="false" />
-
   <node pkg="robot_self_filter" type="configurator.py" name="robot_self_filter_configurator" output="screen">
-    <param name="robot_filter_min_sensor_dist" value="$(arg robot_filter_min_sensor_dist)" />
-    <param name="robot_filter_self_see_default_padding" value="$(arg robot_filter_self_see_default_padding)" />
-    <param name="robot_filter_self_see_default_scale" value="$(arg robot_filter_self_see_default_scale)" />
-    <param name="robot_filter_keep_organized" value="$(arg robot_filter_keep_organized)" />
-    <param name="robot_filter_subsample_value" value="$(arg robot_filter_subsample_value)" />
-    <param name="use_rgb" value="$(arg use_rgb)" />
+    <rosparam command="load" file="$(find robot_self_filter)/config/robot_self_filter.yaml"/>
   </node>
 
+  <arg name="robot_filter_pc_src" default="/photoneo_center/pointcloud" />
+  <arg name="robot_filter_pc_dst" default="/robot_filtered_cloud" />
   <node pkg="timed_roslaunch" type="timed_roslaunch.sh" name="timed_roslaunch" args="2 robot_self_filter self_filter.launch robot_filter_pc_src:=$(arg robot_filter_pc_src) robot_filter_pc_dst:=$(arg robot_filter_pc_dst)" output="screen" />
 
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -37,6 +37,7 @@
   <run_depend>assimp</run_depend>
   <run_depend>tinyxml</run_depend>
   <run_depend>timed_roslaunch</run_depend>
+  <run_depend>urdfdom_py</run_depend>
   <!-- <test_depend>roscpp</test_depend> -->
   <!-- <test_depend>tf</test_depend> -->
   <!-- <test_depend>filters</test_depend> -->

--- a/scripts/configurator.py
+++ b/scripts/configurator.py
@@ -33,14 +33,21 @@ class RobotSelfFilterConfigurator(object):
 
     def link_configure_(self):
         see_linkname_list = self.get_linkname_list_()
+
         if not see_linkname_list:
             rospy.logerr("links not found")
+        
         self_see_links = rospy.get_param("~see_link_names", see_linkname_list)
+
+        see_list = [i.values() for i in see_linkname_list]
+        for link in self_see_links:
+            if link.values() not in see_list:
+                rospy.logerr("%s is not included in urdf.", link.values())
 
         ignore_linkname_list = []
         self_ignore_links = rospy.get_param("~ignore_link_names", ignore_linkname_list)
-
         ignore_list = [i.values() for i in self_ignore_links]
+        
         target_links = [i for i in self_see_links if i.values() not in ignore_list]
         return target_links
 

--- a/scripts/configurator.py
+++ b/scripts/configurator.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
-
 import rospy
-import re
-
+from urdf_parser_py.urdf import URDF
 
 class RobotSelfFilterConfigurator(object):
     def __init__(self, namespace="/self_filter"):
@@ -25,23 +23,32 @@ class RobotSelfFilterConfigurator(object):
             self.semantic_param_name_)
 
     def get_linkname_list_(self):
-        pre_pattern = "(.*)link\ name=(.*)"
-        post_pattern = "(?<=\").*?(?=\")"
-
-        linkname_list = re.findall(post_pattern, "\n".join(
-            map(str, re.findall(pre_pattern, self.robot_description_semantic_))))
-
+        robot = URDF.from_parameter_server();
+        linkname_list = []
+        for link in robot.links:
+            link_name = link.name
+            rospy.loginfo("%s is included in the robot description.", link_name)
+            linkname_list.append({"name": link_name})
         return linkname_list
 
+    def link_configure_(self):
+        see_linkname_list = self.get_linkname_list_()
+        if not see_linkname_list:
+            rospy.logerr("links not found")
+        self_see_links = rospy.get_param("~see_link_names", see_linkname_list)
+
+        ignore_linkname_list = []
+        self_ignore_links = rospy.get_param("~ignore_link_names", ignore_linkname_list)
+
+        ignore_list = [i.values() for i in self_ignore_links]
+        target_links = [i for i in self_see_links if i.values() not in ignore_list]
+        return target_links
+
     def configure(self):
-        linkname_list = self.get_linkname_list_()
-        if not linkname_list:
+        target_linkname_list = self.link_configure_()
+        if not target_linkname_list:
             rospy.logerr("links not found")
             return
-
-        linkname_param_format = []
-        for linkname in linkname_list:
-            linkname_param_format.append({"name": linkname})
 
         rospy.set_param(self.namespace_ + "/min_sensor_dist",
                         self.min_sensor_dist_)
@@ -55,7 +62,7 @@ class RobotSelfFilterConfigurator(object):
                         self.subsample_value_)
         rospy.set_param(self.namespace_ + "/use_rgb", self.use_rgb_)
         rospy.set_param(self.namespace_ + "/self_see_links",
-                        linkname_param_format)
+                        target_linkname_list)
         rospy.loginfo("configure for robot_self_filter is completed")
 
 


### PR DESCRIPTION
今までの実装だとSRDFからlink名を引っ掛けていた実装でしたが、
設定したSRDFによってlink名が定義されていない場合がありました。
おそらくリンク名自体は、URDFから取得したほうが安全だと思ったので
URDFから取得するように変更しています。

またyamlファイルから明示的に指定したい場合もあると思うので、yamlを読むようにlaunchファイルを一部変更しました。
yaml自体の設定項目は
see_link_names: 
ignore_link_names:
です。
上記のパラメータを
なにも設定しない（コメントアウト or 記述しない）場合は、URDFから取得できるlinkすべてがセットされます。
see_link_names: を定義した場合は、URDFからの情報は無視して設定します。
ignore_link_names: を設定した場合は、フィルタを掛けたくないリンク名を指定できます。
see_link_namesとignore_link_namesを併用しても動きますが、冗長となるのでsee_link_namesのignore_link_namesのどちらかを指定する感じです。